### PR TITLE
Refactor JmeAndroidSystem.java to use internal storage (getFilesDir)

### DIFF
--- a/jme3-android/src/main/java/com/jme3/system/android/JmeAndroidSystem.java
+++ b/jme3-android/src/main/java/com/jme3/system/android/JmeAndroidSystem.java
@@ -165,18 +165,18 @@ public class JmeAndroidSystem extends JmeSystemDelegate {
                 //   so the files can be copied to the PC (i.e. screenshots)
                 storageFolder = storageFolders.get(type);
                 if (storageFolder == null) {
-                    String state = Environment.getExternalStorageState();
-                    logger.log(Level.FINE, "ExternalStorageState: {0}", state);
-                    if (state.equals(Environment.MEDIA_MOUNTED)) {
-                        storageFolder = view.getContext().getExternalFilesDir(null);
+                    // Instead of accessing external storage, use internal storage
+                    storageFolder = view.getContext().getFilesDir(); // This accesses the internal storage directory
+                    if (storageFolder != null && storageFolder.exists() && storageFolder.isDirectory()) {
                         storageFolders.put(type, storageFolder);
+                    } else {
+                        logger.log(Level.WARNING, "Internal storage folder is not valid or accessible: {0}", storageFolder);
                     }
                 }
                 break;
             default:
                 break;
-        }
-        if (logger.isLoggable(Level.FINE)) {
+        }        if (logger.isLoggable(Level.FINE)) {
             if (storageFolder != null) {
                 logger.log(Level.FINE, "Base Storage Folder Path: {0}", storageFolder.getAbsolutePath());
             } else {


### PR DESCRIPTION
This PR updates JmeAndroidSystem.java to use internal storage (getFilesDir()) instead of external storage for accessing the storage directory. This change enhances security by ensuring files are stored in a private, app-specific location, preventing unauthorized access and aligning with best practices for secure data storage.

Build Result - 
<img width="1709" alt="Screenshot 2024-12-01 at 2 13 45 PM" src="https://github.com/user-attachments/assets/3532e568-2248-42f6-b7c8-9449a1560a4a">
